### PR TITLE
Cleanup

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,6 @@ import {Route, Routes} from 'react-router-dom';
 import Startpage from "./components/StartPage/Startpage";
 import SearchPage from "./components/SearchPage/SearchPage";
 import {Configuration, DefaultApi, LoginResultDTO} from "./openapi-client";
-import RestrictedWrapper from "./components/LoginPage/RestrictedWrapper";
 import ShoppingCartPage from './components/ShoppingCartPage/ShoppingCartPage';
 
 //set up open api client
@@ -55,7 +54,7 @@ let darkValue: DarkContextType = {
 export const AuthenticationContext = React.createContext(contextValue)
 export const DarkModeContext = React.createContext(darkValue);
 
-function App(this: any) {
+function App() {
     let [authState, setAuthState] = useState(contextValue)
     let [darkState, setDarkState] = useState(darkValue);
 
@@ -112,11 +111,6 @@ function App(this: any) {
                         <Route path="/login" element={<LoginPage fromManualLink={true}/>}/>
                         <Route path="/search" element={<SearchPage/>}/>
                         <Route path="/cart" element={ <ShoppingCartPage/>}/>
-                        <Route path="/restrictedTest" element={
-                            <RestrictedWrapper>
-                                <h1>If you see this without being logged in tell Lukas he fucked up.</h1>
-                            </RestrictedWrapper>
-                        }/>
                     </Routes>
                 </div>
             </DarkModeContext.Provider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React, {useContext, useEffect, useState} from 'react';
 import './App.css';
 import AppHeader from './components/AppHeader/AppHeader';
 import LoginPage from './components/LoginPage/LoginPage';
@@ -31,11 +31,6 @@ export type AuthenticationContextType = {
     logout: () => void;
 }
 
-export type DarkContextType = {
-    dark: boolean;
-    setDark: (b: boolean) => void
-}
-
 let contextValue: AuthenticationContextType = {
     sessionId: "",
     username: "",
@@ -45,33 +40,24 @@ let contextValue: AuthenticationContextType = {
     logout: () => {
     }
 }
-let darkValue: DarkContextType = {
-    dark: true,
-    setDark: () => {
-    }
-}
+
+type DarkModeType = boolean | undefined;
+
+type DarkModeContextType = [
+    DarkModeType,
+    React.Dispatch<React.SetStateAction<DarkModeType>>
+];
+
+const DarkModeContext = React.createContext<DarkModeContextType | undefined>(undefined);
+export const useDarkModeContext = () => useContext(DarkModeContext) as DarkModeContextType;
+
 
 export const AuthenticationContext = React.createContext(contextValue)
-export const DarkModeContext = React.createContext(darkValue);
 
 function App() {
     let [authState, setAuthState] = useState(contextValue)
-    let [darkState, setDarkState] = useState(darkValue);
 
     useEffect(() => {
-        setDarkState(prev => {
-            return {
-                ...prev,
-                setDark: b => {
-                    setDarkState(p => {
-                        return {
-                            ...p,
-                            dark: b
-                        }
-                    })
-                }
-            }
-        })
 
         setAuthState(prevState => {
             return {
@@ -101,10 +87,13 @@ function App() {
         })
     }, []);
 
+    let darkStateArr = useState<DarkModeType>(true);
+    let isDark = darkStateArr[0]; //needed because value of the state is also read in the same component that provides the context
+
     return (
         <AuthenticationContext.Provider value={authState}>
-            <DarkModeContext.Provider value={darkState}>
-                <div className={darkState.dark ? "bp4-dark" : ""} style={darkState.dark ? {backgroundColor: "#616161", minHeight: "100vh"} : {backgroundColor: "white"}}>
+            <DarkModeContext.Provider value={darkStateArr}>
+                <div className={isDark ? "bp4-dark" : ""} style={isDark ? {backgroundColor: "#616161", minHeight: "100vh"} : {backgroundColor: "white"}}>
                     <AppHeader/>
                     <Routes>
                         <Route index element={<Startpage/>}/>

--- a/src/components/AppHeader/AccountIcon/AccountDropdown.tsx
+++ b/src/components/AppHeader/AccountIcon/AccountDropdown.tsx
@@ -1,23 +1,23 @@
 import {MenuItem, Menu, Icon} from "@blueprintjs/core";
 import {useContext} from "react";
-import {AuthenticationContext, DarkModeContext} from "../../../App";
+import {AuthenticationContext, useDarkModeContext} from "../../../App";
 
 function AccountDropdown() {
-    const authenticationContext = useContext(AuthenticationContext)
-    const darkContext = useContext(DarkModeContext)
+    const authenticationContext = useContext(AuthenticationContext);
+    const [isDark, setDarkContext] = useDarkModeContext();
     let loggedIn = authenticationContext.loggedIn;
 
     return (
         <Menu>
             <MenuItem text={"Theme"}>
-                <MenuItem selected={darkContext.dark} text={<>
+                <MenuItem selected={isDark} text={<>
                         <Icon icon={"moon"} /> <span>Dark</span>
                     </>
-                } onClick={() => darkContext.setDark(true)}/>
-                <MenuItem selected={!darkContext.dark} text={<>
+                } onClick={() => setDarkContext(true)}/>
+                <MenuItem selected={!isDark} text={<>
                     <Icon icon={"flash"} /> <span>Light</span>
                 </>
-                } onClick={() => darkContext.setDark(false)}/>
+                } onClick={() => setDarkContext(false)}/>
             </MenuItem>
             {loggedIn && <MenuItem onClick={() => authenticationContext.logout()} text={<><Icon icon={"log-out"}/> <span>Log out</span> </>}/> }
         </Menu>

--- a/src/components/StartPage/Startpage.tsx
+++ b/src/components/StartPage/Startpage.tsx
@@ -11,7 +11,6 @@ function Startpage() {
                 <div className="row">
                     <div className="col-12">
                         <p className="pageTitle">Welcome to Tomify!</p>
-                        <p>If this is shown CI/CD works!</p>
                     </div>
                 </div>
                 <div className="row">
@@ -22,13 +21,6 @@ function Startpage() {
                         <Link to={"/cart"} >
                             <Card elevation={Elevation.FOUR} className={"link-card"} interactive={true}>
                                 <Icon icon={"shopping-cart"} size={100}/>
-                            </Card>
-                        </Link>
-                    </div>
-                    <div className="col-4">
-                        <Link to={"/restrictedTest"} >
-                            <Card elevation={Elevation.FOUR} className={"link-card"} interactive={true}>
-                                <Icon icon={"lock"} size={100}/>
                             </Card>
                         </Link>
                     </div>


### PR DESCRIPTION
removed some unnecessary stuff. CI/CD test, restriction-test

refactored DarkModeContext to directly use React.SetState

only refactored DarkMode because this approach gives full control of the state to all context-consumers, which is fine for a context with just a single attribute but may be not the best for the authentication-context, because the state-changing-methods (login/logout) contain some logic